### PR TITLE
Fix missing if-clause when database is disabled

### DIFF
--- a/charts/supabase/templates/db/storage.yaml
+++ b/charts/supabase/templates/db/storage.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled -}}
 {{- if .Values.db.persistence.enabled -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -17,5 +18,4 @@ spec:
     requests:
       storage: {{ .Values.db.storage.size }}
 {{- end }}
-
-
+{{- end }}


### PR DESCRIPTION
If the database provided is being disabled in values.yaml (e.g. because of using a replicated database solution) the helm installation would fail with:  Error: INSTALLATION FAILED: template: supabase/templates/db/storage.yaml:1:14: executing "supabase/templates/db/storage.yaml" at <.Values.db.persistence.enabled>: nil pointer evaluating interface {}.enabled